### PR TITLE
fix: provider version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this module will be documented in this file.
 
+## [v2.0.1] - 2023-06-15
+
+### Changed
+
+- When running with a provider version of 6 or higher, certain modules may not function properly. However, we can address the modules that are not compatible with version 6 to ensure compatibility. This way, we don't need to edit all the modules. So we update the constraint to `>= 5.0.0` at the module level.
+
 ## [v2.0.0] - 2023-06-08
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ module "logs_kms" {
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name                                                                      | Version           |
-|---------------------------------------------------------------------------|-------------------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0          |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.0.0, < 6.0.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random)          | >= 3.1.0          |
+| Name                                                                      | Version  |
+|---------------------------------------------------------------------------|----------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.0.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random)          | >= 3.1.0 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0, < 6.0.0"
+      version = ">= 5.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## What :kissing:

### Changed

- When running with a provider version of 6 or higher, certain modules may not function properly. However, we can address the modules that are not compatible with version 6 to ensure compatibility. This way, we don't need to edit all the modules. So we update the constraint to `>= 5.0.0` at the module level.

## Why :pleading_face:

- Simplify future upgrade